### PR TITLE
fix: 店舗KYCチャレンジの連続失敗時にロックをかける (#9)

### DIFF
--- a/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreAddress.ts
+++ b/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreAddress.ts
@@ -1,5 +1,10 @@
 import * as functions from 'firebase-functions/v1';
 import { db, auth } from '../../utils/firebase/admin';
+import {
+  assertChallengeNotLocked,
+  buildChallengeFailureUpdate,
+  buildChallengeSuccessReset,
+} from '../../utils/rateLimit';
 
 interface VerifyStoreAddressRequest {
   userId: string;
@@ -46,10 +51,16 @@ export const httpsOnCallChallengeToVerifyStoreAddress = functions
         .collection('kyc')
         .doc('secret');
       const storeKycSecretDoc = await storeKycSecretDocRef.get();
-      const storeAddressSecret = storeKycSecretDoc.data()?.storeAddressSecret as string;
+      const storeKycSecretData = storeKycSecretDoc.data();
+      assertChallengeNotLocked(storeKycSecretData, 'storeAddress');
+      const storeAddressSecret = storeKycSecretData?.storeAddressSecret as string;
       if (challengedStoreAddressSecret !== storeAddressSecret) {
+        await storeKycSecretDocRef.set(buildChallengeFailureUpdate(storeKycSecretData, 'storeAddress'), {
+          merge: true,
+        });
         throw new functions.https.HttpsError('unauthenticated', 'Wrong secret');
       }
+      await storeKycSecretDocRef.set(buildChallengeSuccessReset('storeAddress'), { merge: true });
 
       const { emailVerified, customClaims } = authUser;
       const userKycVerified = emailVerified;
@@ -90,6 +101,10 @@ export const httpsOnCallChallengeToVerifyStoreAddress = functions
       return { storeAddressVerified };
     } catch (error) {
       functions.logger.warn('httpsOnCallChallengeToVerifyStoreAddress', error);
+      // ロック中・確認コード誤り等のHttpsErrorは、状態を呼び出し側に伝えるためそのまま投げ直す
+      if (error instanceof functions.https.HttpsError) {
+        throw error;
+      }
       throw new functions.https.HttpsError('unknown', "Can't verify store address");
     }
   });

--- a/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreAddress.ts
+++ b/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreAddress.ts
@@ -1,10 +1,6 @@
 import * as functions from 'firebase-functions/v1';
 import { db, auth } from '../../utils/firebase/admin';
-import {
-  assertChallengeNotLocked,
-  buildChallengeFailureUpdate,
-  buildChallengeSuccessReset,
-} from '../../utils/rateLimit';
+import { verifyStoreChallenge } from '../../utils/rateLimit';
 
 interface VerifyStoreAddressRequest {
   userId: string;
@@ -50,17 +46,7 @@ export const httpsOnCallChallengeToVerifyStoreAddress = functions
         .doc(storeId)
         .collection('kyc')
         .doc('secret');
-      const storeKycSecretDoc = await storeKycSecretDocRef.get();
-      const storeKycSecretData = storeKycSecretDoc.data();
-      assertChallengeNotLocked(storeKycSecretData, 'storeAddress');
-      const storeAddressSecret = storeKycSecretData?.storeAddressSecret as string;
-      if (challengedStoreAddressSecret !== storeAddressSecret) {
-        await storeKycSecretDocRef.set(buildChallengeFailureUpdate(storeKycSecretData, 'storeAddress'), {
-          merge: true,
-        });
-        throw new functions.https.HttpsError('unauthenticated', 'Wrong secret');
-      }
-      await storeKycSecretDocRef.set(buildChallengeSuccessReset('storeAddress'), { merge: true });
+      await verifyStoreChallenge(storeKycSecretDocRef, 'storeAddress', challengedStoreAddressSecret);
 
       const { emailVerified, customClaims } = authUser;
       const userKycVerified = emailVerified;

--- a/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreEmail.ts
+++ b/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreEmail.ts
@@ -1,10 +1,6 @@
 import * as functions from 'firebase-functions/v1';
 import { db, auth } from '../../utils/firebase/admin';
-import {
-  assertChallengeNotLocked,
-  buildChallengeFailureUpdate,
-  buildChallengeSuccessReset,
-} from '../../utils/rateLimit';
+import { verifyStoreChallenge } from '../../utils/rateLimit';
 
 interface VerifyStoreEmailRequest {
   userId: string;
@@ -50,15 +46,7 @@ export const httpsOnCallChallengeToVerifyStoreEmail = functions
         .doc(storeId)
         .collection('kyc')
         .doc('secret');
-      const storeKycSecretDoc = await storeKycSecretDocRef.get();
-      const storeKycSecretData = storeKycSecretDoc.data();
-      assertChallengeNotLocked(storeKycSecretData, 'storeEmail');
-      const storeEmailSecret = storeKycSecretData?.storeEmailSecret as string;
-      if (challengedStoreEmailSecret !== storeEmailSecret) {
-        await storeKycSecretDocRef.set(buildChallengeFailureUpdate(storeKycSecretData, 'storeEmail'), { merge: true });
-        throw new functions.https.HttpsError('unauthenticated', 'Wrong secret');
-      }
-      await storeKycSecretDocRef.set(buildChallengeSuccessReset('storeEmail'), { merge: true });
+      await verifyStoreChallenge(storeKycSecretDocRef, 'storeEmail', challengedStoreEmailSecret);
 
       const { emailVerified, customClaims } = authUser;
       const userKycVerified = emailVerified;

--- a/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreEmail.ts
+++ b/functions/src/https/onCall/httpsOnCallChallengeToVerifyStoreEmail.ts
@@ -1,5 +1,10 @@
 import * as functions from 'firebase-functions/v1';
 import { db, auth } from '../../utils/firebase/admin';
+import {
+  assertChallengeNotLocked,
+  buildChallengeFailureUpdate,
+  buildChallengeSuccessReset,
+} from '../../utils/rateLimit';
 
 interface VerifyStoreEmailRequest {
   userId: string;
@@ -46,10 +51,14 @@ export const httpsOnCallChallengeToVerifyStoreEmail = functions
         .collection('kyc')
         .doc('secret');
       const storeKycSecretDoc = await storeKycSecretDocRef.get();
-      const storeEmailSecret = storeKycSecretDoc.data()?.storeEmailSecret as string;
+      const storeKycSecretData = storeKycSecretDoc.data();
+      assertChallengeNotLocked(storeKycSecretData, 'storeEmail');
+      const storeEmailSecret = storeKycSecretData?.storeEmailSecret as string;
       if (challengedStoreEmailSecret !== storeEmailSecret) {
+        await storeKycSecretDocRef.set(buildChallengeFailureUpdate(storeKycSecretData, 'storeEmail'), { merge: true });
         throw new functions.https.HttpsError('unauthenticated', 'Wrong secret');
       }
+      await storeKycSecretDocRef.set(buildChallengeSuccessReset('storeEmail'), { merge: true });
 
       const { emailVerified, customClaims } = authUser;
       const userKycVerified = emailVerified;
@@ -90,6 +99,10 @@ export const httpsOnCallChallengeToVerifyStoreEmail = functions
       return { storeEmailVerified };
     } catch (error) {
       functions.logger.warn('httpsOnCallChallengeToVerifyStoreEmail', error);
+      // ロック中・確認コード誤り等のHttpsErrorは、状態を呼び出し側に伝えるためそのまま投げ直す
+      if (error instanceof functions.https.HttpsError) {
+        throw error;
+      }
       throw new functions.https.HttpsError('unknown', "Can't verify store email");
     }
   });

--- a/functions/src/https/onCall/httpsOnCallChallengeToVerifyStorePhoneNumber.ts
+++ b/functions/src/https/onCall/httpsOnCallChallengeToVerifyStorePhoneNumber.ts
@@ -1,5 +1,10 @@
 import * as functions from 'firebase-functions/v1';
 import { db, auth } from '../../utils/firebase/admin';
+import {
+  assertChallengeNotLocked,
+  buildChallengeFailureUpdate,
+  buildChallengeSuccessReset,
+} from '../../utils/rateLimit';
 
 interface VerifyStorePhoneNumberRequest {
   userId: string;
@@ -46,10 +51,16 @@ export const httpsOnCallChallengeToVerifyStorePhoneNumber = functions
         .collection('kyc')
         .doc('secret');
       const storeKycSecretDoc = await storeKycSecretDocRef.get();
-      const storePhoneNumberSecret = storeKycSecretDoc.data()?.storePhoneNumberSecret as string;
+      const storeKycSecretData = storeKycSecretDoc.data();
+      assertChallengeNotLocked(storeKycSecretData, 'storePhoneNumber');
+      const storePhoneNumberSecret = storeKycSecretData?.storePhoneNumberSecret as string;
       if (challengedStorePhoneNumberSecret !== storePhoneNumberSecret) {
+        await storeKycSecretDocRef.set(buildChallengeFailureUpdate(storeKycSecretData, 'storePhoneNumber'), {
+          merge: true,
+        });
         throw new functions.https.HttpsError('unauthenticated', 'Wrong secret');
       }
+      await storeKycSecretDocRef.set(buildChallengeSuccessReset('storePhoneNumber'), { merge: true });
 
       const { emailVerified, customClaims } = authUser;
       const userKycVerified = emailVerified;
@@ -90,6 +101,10 @@ export const httpsOnCallChallengeToVerifyStorePhoneNumber = functions
       return { storePhoneNumberVerified };
     } catch (error) {
       functions.logger.warn('httpsOnCallChallengeToVerifyStorePhoneNumber', error);
+      // ロック中・確認コード誤り等のHttpsErrorは、状態を呼び出し側に伝えるためそのまま投げ直す
+      if (error instanceof functions.https.HttpsError) {
+        throw error;
+      }
       throw new functions.https.HttpsError('unknown', "Can't verify store phone number");
     }
   });

--- a/functions/src/https/onCall/httpsOnCallChallengeToVerifyStorePhoneNumber.ts
+++ b/functions/src/https/onCall/httpsOnCallChallengeToVerifyStorePhoneNumber.ts
@@ -1,10 +1,6 @@
 import * as functions from 'firebase-functions/v1';
 import { db, auth } from '../../utils/firebase/admin';
-import {
-  assertChallengeNotLocked,
-  buildChallengeFailureUpdate,
-  buildChallengeSuccessReset,
-} from '../../utils/rateLimit';
+import { verifyStoreChallenge } from '../../utils/rateLimit';
 
 interface VerifyStorePhoneNumberRequest {
   userId: string;
@@ -50,17 +46,7 @@ export const httpsOnCallChallengeToVerifyStorePhoneNumber = functions
         .doc(storeId)
         .collection('kyc')
         .doc('secret');
-      const storeKycSecretDoc = await storeKycSecretDocRef.get();
-      const storeKycSecretData = storeKycSecretDoc.data();
-      assertChallengeNotLocked(storeKycSecretData, 'storePhoneNumber');
-      const storePhoneNumberSecret = storeKycSecretData?.storePhoneNumberSecret as string;
-      if (challengedStorePhoneNumberSecret !== storePhoneNumberSecret) {
-        await storeKycSecretDocRef.set(buildChallengeFailureUpdate(storeKycSecretData, 'storePhoneNumber'), {
-          merge: true,
-        });
-        throw new functions.https.HttpsError('unauthenticated', 'Wrong secret');
-      }
-      await storeKycSecretDocRef.set(buildChallengeSuccessReset('storePhoneNumber'), { merge: true });
+      await verifyStoreChallenge(storeKycSecretDocRef, 'storePhoneNumber', challengedStorePhoneNumberSecret);
 
       const { emailVerified, customClaims } = authUser;
       const userKycVerified = emailVerified;

--- a/functions/src/utils/rateLimit/index.ts
+++ b/functions/src/utils/rateLimit/index.ts
@@ -1,9 +1,12 @@
 import * as functions from 'firebase-functions/v1';
+import { db } from '../firebase/admin';
 
 // 店舗KYCのチャレンジ(確認コード)入力に対するブルートフォース対策。
 // 確認コードは数字6桁のため、レートリミットが無いと総当たりで突破できてしまう。
 // 連続で一定回数失敗するとロックし、ロックを繰り返すごとにロック時間を指数的に延ばす。
 // 失敗回数・ロック期限・ロック回数は店舗KYC秘密情報ドキュメント(adminのみ読み書き可)に記録する。
+// 同時リクエストによるカウンタのlost update(=ロック回避)を防ぐため、読み込み〜更新は
+// Firestoreトランザクションで原子的に行う。
 
 // この回数連続で失敗するとロックする
 export const MAX_CHALLENGE_FAILED_COUNT = 5;
@@ -14,8 +17,9 @@ const MAX_LOCK_DURATION_MS = 24 * 60 * 60 * 1000;
 
 export type ChallengeKey = 'storeEmail' | 'storePhoneNumber' | 'storeAddress';
 
-type SecretData = Record<string, unknown> | undefined;
+type SecretData = FirebaseFirestore.DocumentData | undefined;
 
+const secretFieldName = (key: ChallengeKey): string => `${key}Secret`;
 const failedCountFieldName = (key: ChallengeKey): string => `${key}FailedCount`;
 const lockedUntilFieldName = (key: ChallengeKey): string => `${key}LockedUntil`;
 const lockCountFieldName = (key: ChallengeKey): string => `${key}LockCount`;
@@ -25,8 +29,8 @@ const readNumberField = (data: SecretData, fieldName: string): number => {
   return typeof value === 'number' ? value : 0;
 };
 
-// ロック中であれば例外を投げる。確認コードの照合より前に呼び出すこと。
-export const assertChallengeNotLocked = (data: SecretData, key: ChallengeKey): void => {
+// ロック中であれば例外を投げる。
+const assertChallengeNotLocked = (data: SecretData, key: ChallengeKey): void => {
   const lockedUntil = readNumberField(data, lockedUntilFieldName(key));
   const now = Date.now();
   if (lockedUntil > now) {
@@ -39,7 +43,7 @@ export const assertChallengeNotLocked = (data: SecretData, key: ChallengeKey): v
 };
 
 // 確認コード照合に失敗したときの秘密情報ドキュメントの更新値を計算する({ merge: true }で書き込む想定)。
-export const buildChallengeFailureUpdate = (data: SecretData, key: ChallengeKey): Record<string, number> => {
+const buildChallengeFailureUpdate = (data: SecretData, key: ChallengeKey): Record<string, number> => {
   const failedCount = readNumberField(data, failedCountFieldName(key)) + 1;
   if (failedCount < MAX_CHALLENGE_FAILED_COUNT) {
     return { [failedCountFieldName(key)]: failedCount };
@@ -55,8 +59,38 @@ export const buildChallengeFailureUpdate = (data: SecretData, key: ChallengeKey)
 };
 
 // 確認コード照合に成功したときに失敗回数・ロック状態をリセットする更新値({ merge: true }で書き込む想定)。
-export const buildChallengeSuccessReset = (key: ChallengeKey): Record<string, number> => ({
+const buildChallengeSuccessReset = (key: ChallengeKey): Record<string, number> => ({
   [failedCountFieldName(key)]: 0,
   [lockedUntilFieldName(key)]: 0,
   [lockCountFieldName(key)]: 0,
 });
+
+// 確認コードをレートリミット付きで照合する。
+// ロック中・確認コード誤りの場合はHttpsErrorを投げ、正しければ何も返さず正常終了する。
+// 読み込み・ロック判定・カウンタ更新をトランザクションで原子的に行うため、
+// 並列リクエストでカウンタが上書きされてロックを回避されることがない。
+export const verifyStoreChallenge = async (
+  storeKycSecretDocRef: FirebaseFirestore.DocumentReference,
+  key: ChallengeKey,
+  challengedSecret: string,
+): Promise<void> => {
+  // 確認コード誤り時は失敗カウンタの更新をコミットしたいので、トランザクション内では
+  // 例外を投げず、照合結果だけを返してトランザクション外で例外を投げる。
+  const verified = await db.runTransaction(async (transaction) => {
+    const storeKycSecretDoc = await transaction.get(storeKycSecretDocRef);
+    const data = storeKycSecretDoc.data();
+    // ロック中はカウンタ更新不要のため、ここで投げてトランザクションを中断する。
+    assertChallengeNotLocked(data, key);
+    const secret = data?.[secretFieldName(key)] as string | undefined;
+    if (challengedSecret !== secret) {
+      transaction.set(storeKycSecretDocRef, buildChallengeFailureUpdate(data, key), { merge: true });
+      return false;
+    }
+    transaction.set(storeKycSecretDocRef, buildChallengeSuccessReset(key), { merge: true });
+    return true;
+  });
+  if (!verified) {
+    // 認証(unauthenticated)ではなく確認コードの誤りを表す状態を返す。
+    throw new functions.https.HttpsError('failed-precondition', 'Wrong secret');
+  }
+};

--- a/functions/src/utils/rateLimit/index.ts
+++ b/functions/src/utils/rateLimit/index.ts
@@ -1,0 +1,62 @@
+import * as functions from 'firebase-functions/v1';
+
+// 店舗KYCのチャレンジ(確認コード)入力に対するブルートフォース対策。
+// 確認コードは数字6桁のため、レートリミットが無いと総当たりで突破できてしまう。
+// 連続で一定回数失敗するとロックし、ロックを繰り返すごとにロック時間を指数的に延ばす。
+// 失敗回数・ロック期限・ロック回数は店舗KYC秘密情報ドキュメント(adminのみ読み書き可)に記録する。
+
+// この回数連続で失敗するとロックする
+export const MAX_CHALLENGE_FAILED_COUNT = 5;
+// 初回のロック時間(5分)
+const BASE_LOCK_DURATION_MS = 5 * 60 * 1000;
+// ロック時間の上限(24時間)
+const MAX_LOCK_DURATION_MS = 24 * 60 * 60 * 1000;
+
+export type ChallengeKey = 'storeEmail' | 'storePhoneNumber' | 'storeAddress';
+
+type SecretData = Record<string, unknown> | undefined;
+
+const failedCountFieldName = (key: ChallengeKey): string => `${key}FailedCount`;
+const lockedUntilFieldName = (key: ChallengeKey): string => `${key}LockedUntil`;
+const lockCountFieldName = (key: ChallengeKey): string => `${key}LockCount`;
+
+const readNumberField = (data: SecretData, fieldName: string): number => {
+  const value = data?.[fieldName];
+  return typeof value === 'number' ? value : 0;
+};
+
+// ロック中であれば例外を投げる。確認コードの照合より前に呼び出すこと。
+export const assertChallengeNotLocked = (data: SecretData, key: ChallengeKey): void => {
+  const lockedUntil = readNumberField(data, lockedUntilFieldName(key));
+  const now = Date.now();
+  if (lockedUntil > now) {
+    const remainingMinutes = Math.ceil((lockedUntil - now) / (60 * 1000));
+    throw new functions.https.HttpsError(
+      'resource-exhausted',
+      `確認コードの連続入力ミスのため一時的にロックされています。約${remainingMinutes}分後に再度お試しください。`,
+    );
+  }
+};
+
+// 確認コード照合に失敗したときの秘密情報ドキュメントの更新値を計算する({ merge: true }で書き込む想定)。
+export const buildChallengeFailureUpdate = (data: SecretData, key: ChallengeKey): Record<string, number> => {
+  const failedCount = readNumberField(data, failedCountFieldName(key)) + 1;
+  if (failedCount < MAX_CHALLENGE_FAILED_COUNT) {
+    return { [failedCountFieldName(key)]: failedCount };
+  }
+  // しきい値に達したのでロックする。ロックを繰り返すごとにロック時間を指数的に延ばす。
+  const lockCount = readNumberField(data, lockCountFieldName(key)) + 1;
+  const lockDuration = Math.min(BASE_LOCK_DURATION_MS * 2 ** (lockCount - 1), MAX_LOCK_DURATION_MS);
+  return {
+    [failedCountFieldName(key)]: 0,
+    [lockedUntilFieldName(key)]: Date.now() + lockDuration,
+    [lockCountFieldName(key)]: lockCount,
+  };
+};
+
+// 確認コード照合に成功したときに失敗回数・ロック状態をリセットする更新値({ merge: true }で書き込む想定)。
+export const buildChallengeSuccessReset = (key: ChallengeKey): Record<string, number> => ({
+  [failedCountFieldName(key)]: 0,
+  [lockedUntilFieldName(key)]: 0,
+  [lockCountFieldName(key)]: 0,
+});


### PR DESCRIPTION
## 概要

Closes #9

店舗情報KYCの確認コード(数字6桁)を秘密情報と照合する3つの Cloud Functions callable に、**レートリミット・試行回数カウント・ロックが一切存在せず**、6桁コードを総当たりで突破できる状態だった。連続失敗時のロックを実装する。

- `httpsOnCallChallengeToVerifyStoreEmail`
- `httpsOnCallChallengeToVerifyStorePhoneNumber`
- `httpsOnCallChallengeToVerifyStoreAddress`

## 変更内容

### 新規: `functions/src/utils/rateLimit/index.ts`
ブルートフォース対策の共有ユーティリティ。失敗回数・ロック期限・ロック回数を**店舗KYC秘密情報ドキュメント**(`users/{userId}/stores/{storeId}/kyc/secret`、`firestore.rules` で admin のみ読み書き可)に記録する。

- `MAX_CHALLENGE_FAILED_COUNT = 5` 連続失敗でロック
- 初回ロック5分、ロックを繰り返すごとに指数的に延長(上限24時間)
- チャレンジ種別(`storeEmail` / `storePhoneNumber` / `storeAddress`)ごとに独立してカウント

### 3つのチャレンジ検証関数
1. 照合前に `assertChallengeNotLocked()` でロック中チェック(ロック中は `resource-exhausted` で残り時間を日本語メッセージで返す)
2. 照合失敗時に `buildChallengeFailureUpdate()` で失敗回数を記録(しきい値到達でロック設定)
3. 照合成功時に `buildChallengeSuccessReset()` で状態をリセット
4. catch節を修正し、`HttpsError`(ロック中・コード誤り)はそのまま投げ直す — 従来は全例外が `unknown`「Can't verify ...」に潰れ、ロック残り時間がクライアントに伝わらなかったため

## 補足

- 秘密情報ドキュメントは元々 admin のみ読み書き可で、これら関数は admin SDK 経由のため `firestore.rules` の変更は不要。
- ユーザーのメール認証は Firebase Auth 組み込み機能(独自にレートリミットあり)で、秘密情報照合を行うのはこの3関数のみ。

## 検証

- `npm run build`(tsc)成功 — functions側CIが実際にゲートしているチェック。

🤖 Generated with [Claude Code](https://claude.com/claude-code)