### PR TITLE
ci: ワークフローに最小権限を明示し Code scanning 警告を解消

### DIFF
--- a/.github/workflows/ci-functions.yml
+++ b/.github/workflows/ci-functions.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout のみ。書き込み権限は不要
     strategy:
       matrix:
         node: ['22']

--- a/.github/workflows/ci-react.yml
+++ b/.github/workflows/ci-react.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout のみ。書き込み権限は不要
     strategy:
       # 1 つのチェックが落ちても他のチェックは最後まで走らせる（全失敗を一覧したい）
       fail-fast: false


### PR DESCRIPTION
## 概要

GitHub の Security and quality に残っていた **Code scanning 警告 2件** に対応します。

| # | ファイル | ルール |
|---|---|---|
| 1 | `.github/workflows/ci-functions.yml` | `actions/missing-workflow-permissions` (warning) |
| 2 | `.github/workflows/ci-react.yml` | `actions/missing-workflow-permissions` (warning) |

`permissions:` ブロックが無いと `GITHUB_TOKEN` に既定の広い権限が付与されます。両 CI ジョブは **checkout と npm 実行のみ**で書き込みは不要なため、CD ワークフロー（`cd-*-firebase.yml`）と同じ **job 単位**のスタイルで `permissions: contents: read` を明示し、最小権限化します。

## 確認

- YAML パース OK
- ワークフローの実処理（matrix / steps / audit ゲート）は変更なし

## 残課題（このPRでは対応しない脆弱性）

Security の Vulnerabilities 3件は、いずれもクリーンな上流修正が無いため別途継続調査とします（既存の方針を踏襲）:

- **uuid `<11.1.1`（functions, #66）** — `firebase-admin@13` の推移的依存。修正版の `firebase-admin@14` は `firebase-functions@7`（最新）の peer 範囲（`^11||^12||^13`）が受け付けないためブロック中。firebase-functions が 14 対応した時点で解消。
- **uuid `<11.1.1`（root, #286）** — devDep CLI の `firebase-tools` 経由（`gaxios` → uuid@9）。本番バンドルには含まれず実行時露出なし。
- **elliptic `<=6.6.1`（#174, low）** — 6.6.1 が最新で patched version 無し。Symbol SDK / Vite node polyfills 経由。上流修正待ち。

🤖 Generated with [Claude Code](https://claude.com/claude-code)